### PR TITLE
Fix license and add keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/Sickboy78/MMM-Homematic.git"
   },
-  "keywords": [],
+  "keywords": [homematic, smarthome],
   "author": "Sickboy78",
-  "license": "GPL",
+  "license": "GPL-3.0-only",
   "bugs": {
     "url": "https://github.com/Sickboy78/MMM-Homematic/issues"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/Sickboy78/MMM-Homematic.git"
   },
-  "keywords": [homematic, smarthome],
+  "keywords": ["homematic", "smarthome"],
   "author": "Sickboy78",
   "license": "GPL-3.0-only",
   "bugs": {


### PR DESCRIPTION
License has to be a valid SPDX identifier: https://spdx.org/licenses/.